### PR TITLE
Don't rely on `set` being required implicitly

### DIFF
--- a/lib/futuroscope/pool.rb
+++ b/lib/futuroscope/pool.rb
@@ -1,3 +1,4 @@
+require 'set'
 require 'thread'
 require 'futuroscope/worker'
 


### PR DESCRIPTION
Many libraries (e.g. `rails`, `rspec`, etc) require `set`, but non rails applications don't by default.

The issue was encountered when I was experimenting with the library via a fresh ruby console (i.e. `pry` or `irb`).

```
$ irb
irb(main):001:0> require 'futuroscope'
=> true
irb(main):002:0> x = Futuroscope::Future.new{ sleep(1); 1 }
NameError: uninitialized constant Futuroscope::Pool::Set
    from /Users/bayan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/futuroscope-0.1.5/lib/futuroscope/pool.rb:19:in `initialize'
    from /Users/bayan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/futuroscope-0.1.5/lib/futuroscope.rb:11:in `new'
    from /Users/bayan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/futuroscope-0.1.5/lib/futuroscope.rb:11:in `default_pool'
    from /Users/bayan/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/futuroscope-0.1.5/lib/futuroscope/future.rb:29:in `initialize'
    from (irb):2:in `new'
    from (irb):2
    from /Users/bayan/.rbenv/versions/2.0.0-p247/bin/irb:12:in `<main>'
irb(main):003:0> 
```
