### PR TITLE
Allow marshalling of Future instances

### DIFF
--- a/lib/futuroscope/future.rb
+++ b/lib/futuroscope/future.rb
@@ -51,6 +51,14 @@ module Futuroscope
       resolved[:value]
     end
 
+    def marshal_dump
+      resolved_future_value
+    end
+
+    def __setobj__ obj
+      @resolved_future = obj
+    end
+
     def_delegators :__getobj__, :class, :kind_of?, :is_a?, :clone
 
     alias_method :future_value, :__getobj__

--- a/spec/futuroscope/future_spec.rb
+++ b/spec/futuroscope/future_spec.rb
@@ -51,5 +51,13 @@ module Futuroscope
 
       expect(future.future_value.object_id === object.object_id).to eq(true)
     end
+
+    it "marshals a future object by serializing the result value" do
+      object = [1, 2, 3]
+      future = Future.new{object}
+      dumped = Marshal.dump(future)
+      expect(Marshal.load(dumped).future_value).to eq(object)
+    end
+
   end
 end


### PR DESCRIPTION
Before this would fail with an error that Mutex can't be marshalled.
This commit changes the logic so that marshalling will wait until the
future is finished and then marshals the object.

It also needs to define `__setobj__` so it the object can be properly
unmarshalled.

This was discovered because an object containing a future was used in
Rails caching which uses Marshal.
