### PR TITLE
Fixed race condition with 2 threads waiting on the same future

### DIFF
--- a/lib/futuroscope/future.rb
+++ b/lib/futuroscope/future.rb
@@ -30,6 +30,7 @@ module Futuroscope
       @queue = ::SizedQueue.new(1)
       @pool = pool
       @block = block
+      @mutex = Mutex.new
       @pool.queue self
     end
 
@@ -70,7 +71,9 @@ module Futuroscope
     private
 
     def resolved_future_value
-      @resolved_future ||= @queue.pop
+      @resolved_future || @mutex.synchronize do
+        @resolved_future ||= @queue.pop
+      end
     end
   end
 end

--- a/spec/futuroscope/future_spec.rb
+++ b/spec/futuroscope/future_spec.rb
@@ -66,5 +66,32 @@ module Futuroscope
       expect(future.dup).to eq future
     end
 
+    context "when at least another thread is alive" do
+      # If no threads are alive, the VM raises an exception, therefore we need to ensure there is one.
+
+      before :each do
+        @live_thread = Thread.new { loop { } }
+      end
+
+
+      it "doesn't hang when 2 threads try to obtain its result before it's finished" do
+        test_thread = Thread.new do
+          future = Future.new { sleep 1; 1 }
+          f1 = Future.new { future + 1 }
+          f2 = Future.new { future + 2 }
+          f1.future_value
+          f2.future_value
+        end
+        sleep 2
+        expect(test_thread).to_not be_alive
+        test_thread.kill
+      end
+
+
+      after :each do
+        @live_thread.kill
+      end
+
+    end
   end
 end


### PR DESCRIPTION
When 2 threads try to access the same future that has not been resolved yet, both threads start to pop the future's internal queue. But since only one value will ever get pushed to that queue, one of the threads will hang forever.

The solution is to use a mutex, preferably with [double checked locking](http://en.wikipedia.org/wiki/Double-checked_locking) on `resolved_future_value`. This way only one thread will ever block the Future's internal queue, the rest blocks on the mutex and will correctly obtain the value afterwards.

This behavior might have sparked the following line in the original blog post:

> You could reach dead locks when you're calling futures inside of futures (because of the thread pool). You shouldn't be doing that.

Currently I see no other way of reaching a deadlock, so this might be obsolete information after the fix, but I haven't proven this.
