### PR TITLE
Passing through #nil?

### DIFF
--- a/lib/futuroscope/future.rb
+++ b/lib/futuroscope/future.rb
@@ -64,7 +64,7 @@ module Futuroscope
       @resolved_future = value
     end
 
-    def_delegators :__getobj__, :class, :kind_of?, :is_a?, :clone
+    def_delegators :__getobj__, :class, :kind_of?, :is_a?, :clone, :nil?
 
     alias_method :future_value, :__getobj__
 

--- a/spec/futuroscope/future_spec.rb
+++ b/spec/futuroscope/future_spec.rb
@@ -29,6 +29,7 @@ module Futuroscope
       expect(future).to be_a(Enumerable)
       expect(future.clone).to eq(object)
       expect(future.to_s).to eq(object.to_s)
+      expect(Future.new { nil }).to be_nil
     end
 
     it "delegates missing methods" do


### PR DESCRIPTION
future { nil }.nil? returns false, I think this method should be forwarded.

Also recommend removing :clone from the forwarded methods, because duplication was fixed in #13, and I see no reason to return the encapsulated object when cloning. (That is not included in this PR.)
