### PR TITLE
Future should not marschal when it contains exceptions

### DIFF
--- a/lib/futuroscope/future.rb
+++ b/lib/futuroscope/future.rb
@@ -46,10 +46,7 @@ module Futuroscope
     #
     # Returns the Future's block execution result.
     def __getobj__
-      resolved = resolved_future_value
-
-      raise resolved[:exception] if resolved[:exception]
-      resolved[:value]
+      resolved_future_value_or_raise[:value]
     end
 
     def __setobj__ obj
@@ -57,7 +54,7 @@ module Futuroscope
     end
 
     def marshal_dump
-      resolved_future_value
+      resolved_future_value_or_raise
     end
 
     def marshal_load value
@@ -69,6 +66,13 @@ module Futuroscope
     alias_method :future_value, :__getobj__
 
     private
+
+    def resolved_future_value_or_raise
+      resolved = resolved_future_value
+
+      raise resolved[:exception] if resolved[:exception]
+      resolved
+    end
 
     def resolved_future_value
       @resolved_future || @mutex.synchronize do

--- a/spec/futuroscope/future_spec.rb
+++ b/spec/futuroscope/future_spec.rb
@@ -59,6 +59,14 @@ module Futuroscope
       expect(Marshal.load(dumped).future_value).to eq(object)
     end
 
+    it "re-raises captured exception when trying to marshal" do
+      future = Future.new{ raise Exception }
+
+      expect(lambda{
+        Marshal.dump(future)
+      }).to raise_error(Exception)
+    end
+
     it "correctly duplicates a future object" do
       object = [1, 2, 3]
       future = Future.new { object }


### PR DESCRIPTION
The reason for this fix is that, when you cache a future that produces an exception you are storing an exception state. Which in my opinion does not make sence.
