### PR TITLE
Changed blog post url. Previous blog post was not found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ it's finished. Otherwise, it will immediately return its value.
 
 Futuroscope is tested on `MRI 1.9.3`, `MRI 2.0.0`, `MRI 2.1.0`, `Rubinius (2.2.3)` and `JRuby (1.9)`.
 
-Check out [futuroscope's post on Codegram's blog](http://blog.codegram.com/2013/5/new-gem-released-futuroscope) to get started.
+Check out [futuroscope's post on Codegram's blog](http://thoughts.codegram.com/new-gem-released-futuroscope/) to get started.
 
 ## Installation
 


### PR DESCRIPTION
README links to http://blog.codegram.com/2013/5/new-gem-released-futuroscope. This URL is no longer valid. It looks like the post was moved to http://thoughts.codegram.com/new-gem-released-futuroscope/. 

